### PR TITLE
modify definition of "blockchain ID"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ console.log(profile)
 
 ### Usernames
 
-A blockchain ID = a name + a blockchain ID
+A blockchain ID = a name + a profile, registered on a blockchain.
 
 Let's say you register the username 'alice' within the 'id' namespace, the default namespace for usernames. Then your username would be expressed as `alice.id`.
 


### PR DESCRIPTION
Previously: 

A blockchain ID = a name + a blockchain ID

Current:

A blockchain ID = a name + a profile, registered on a blockchain

Reason:

saying "a blockchain ID = a name + a blockchain ID" is confusing. A blockchain ID = a blockchain ID + some other thing? That can't be right.

To resolve the confusion, I have clarified by stating that a blockchain ID is actually a name + a profile, both of which have been registered on a blockchain. We must now think about whether we are going to give these names a special name like "blockchain domain name" or something like that. Until now, we have said that both the name and the name+profile are called a "blockchain ID."

Alternative:

A blockchain ID = a unique name that has been registered on a blockchain

It is not necessary to have a "profile," such as that seen with a profile explorer like onename.com, for the blockchain ID to be valid. The blockchain ID zone file could instead contain pointers to information relevant to other applications without necessitating a full blown profile e.g. OpenBazaar GUID, ZeroNet TLD, KYC data for identity authentication, etc.
